### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Uploaders: Vincent Bernat <bernat@debian.org>
 Build-Depends: debhelper-compat (= 13),
                cmake,
                libgtest-dev (>= 1.8.1)
-Standards-Version: 4.5.0
+Standards-Version: 4.6.0
 Section: libs
 Homepage: https://github.com/xtensor-stack/xtl
 Vcs-Browser: https://github.com/quantstack-debian/xtl

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: xtl
 Priority: optional
 Maintainer: Debian QuantStack Team <team+debian-quantstack-team@tracker.debian.org>
 Uploaders: Vincent Bernat <bernat@debian.org>
-Build-Depends: debhelper-compat (= 12),
+Build-Depends: debhelper-compat (= 13),
                cmake,
                libgtest-dev (>= 1.8.1)
 Standards-Version: 4.5.0

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,5 @@
+---
+Bug-Database: https://github.com/xtensor-stack/xtl/issues
+Bug-Submit: https://github.com/xtensor-stack/xtl/issues/new
+Repository: https://github.com/xtensor-stack/xtl.git
+Repository-Browse: https://github.com/xtensor-stack/xtl


### PR DESCRIPTION
Fix some issues reported by lintian

* Bump debhelper from old 12 to 13. ([package-uses-old-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-old-debhelper-compat-version))

* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository))

* Update standards version to 4.6.0, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/xtl/1a2fff76-c7e3-446e-a4a8-aad413e6b87a.
